### PR TITLE
Fix Music Customizer bypass having the wrong name (en-US/GB)

### DIFF
--- a/langs/en-GB.json
+++ b/langs/en-GB.json
@@ -16,7 +16,7 @@
   "BYPASS": "Bypass",
   "BYPASS/HACK_MAIN_LEVELS": "Main Levels",
   "BYPASS/HACK_MAIN_LEVELS/TIP": "Unlocks main demon levels",
-  "BYPASS/HACK_MUSIC_UNLOCKER": "Music Unlocker",
+  "BYPASS/HACK_MUSIC_UNLOCKER": "Music Customiser",
   "BYPASS/HACK_MUSIC_UNLOCKER/TIP": "Allows for custom practice and menu music",
   "BYPASS/HACK_SLIDER_LIMIT": "Slider Limit",
   "BYPASS/HACK_SLIDER_LIMIT/TIP": "Lets sliders be dragged beyond the visible limit",

--- a/langs/en-US.json
+++ b/langs/en-US.json
@@ -16,7 +16,7 @@
   "BYPASS": "Bypass",
   "BYPASS/HACK_MAIN_LEVELS": "Main Levels",
   "BYPASS/HACK_MAIN_LEVELS/TIP": "Unlocks main demon levels",
-  "BYPASS/HACK_MUSIC_UNLOCKER": "Music Unlocker",
+  "BYPASS/HACK_MUSIC_UNLOCKER": "Music Customizer",
   "BYPASS/HACK_MUSIC_UNLOCKER/TIP": "Allows for custom practice and menu music",
   "BYPASS/HACK_SLIDER_LIMIT": "Slider Limit",
   "BYPASS/HACK_SLIDER_LIMIT/TIP": "Lets sliders be dragged beyond the visible limit",


### PR DESCRIPTION
wasnt this fixed several updates ago? why does it have the wrong name again